### PR TITLE
Enhance capability to add min/max instances

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,15 @@
+output "settings" {
+  value = [
+    {
+      namespace = "aws:autoscaling:asg"
+      name      = "MinSize"
+      value     = var.minimum_instances
+
+    },
+    {
+      namespace = "aws:autoscaling:asg"
+      name      = "MaxSize"
+      value     = var.maximum_instances
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,21 @@ EOF
   type    = map(string)
   default = {}
 }
+
+variable "minimum_instances" {
+  type        = number
+  default     = 1
+  description = <<EOF
+The minimum number of instances that you want.
+See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.as.html for details on autoscaling
+EOF
+}
+
+variable "maximum_instances" {
+  type        = number
+  default     = 4
+  description = <<EOF
+The maximum number of instances that you want.
+See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/using-features.managing.as.html for details on autoscaling
+EOF
+}


### PR DESCRIPTION
This change requires [this PR](https://github.com/nullstone-modules/aws-beanstalk-app/pull/4) in order to enable beanstalk capabilities.